### PR TITLE
feat(metrics): add basic kafka metrics

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,35 @@
+export function initMetrics (prometheus) {
+  if (!prometheus?.registry || !prometheus?.client) return null
+  const { client, registry } = prometheus
+
+  return {
+    messagesProcessed: new client.Counter({
+      name: 'kafka_hooks_messages_processed_total',
+      help: 'Total number of messages successfully processed',
+      labelNames: ['topic', 'status'], // status => 'success', 'failed'
+      registers: [registry]
+    }),
+
+    messagesInFlight: new client.Gauge({
+      name: 'kafka_hooks_messages_in_flight',
+      help: 'Number of messages currently being processed',
+      labelNames: ['topic'],
+      registers: [registry]
+    }),
+
+    httpRequestDuration: new client.Histogram({
+      name: 'kafka_hooks_http_request_duration_seconds',
+      help: 'HTTP request duration for webhook deliveries',
+      labelNames: ['topic', 'method', 'status_code'],
+      buckets: [0.1, 0.5, 1, 2, 5, 10],
+      registers: [registry]
+    }),
+
+    dlqMessages: new client.Counter({
+      name: 'kafka_hooks_dlq_messages_total',
+      help: 'Total number of messages sent to the DLQ (Dead Letter Queue)',
+      labelNames: ['topic', 'reason'],
+      registers: [registry]
+    })
+  }
+}

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -3,13 +3,6 @@ export function initMetrics (prometheus) {
   const { client, registry } = prometheus
 
   return {
-    messagesProcessed: new client.Counter({
-      name: 'kafka_hooks_messages_processed_total',
-      help: 'Total number of messages successfully processed',
-      labelNames: ['topic', 'status'], // status => 'success', 'failed'
-      registers: [registry]
-    }),
-
     messagesInFlight: new client.Gauge({
       name: 'kafka_hooks_messages_in_flight',
       help: 'Number of messages currently being processed',

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,42 +17,7 @@ import {
   pathParamsHeader,
   queryStringHeader
 } from './definitions.js'
-
-function initMetrics (prometheus) {
-  if (!prometheus?.registry || !prometheus?.client) return null
-  const { client, registry } = prometheus
-
-  return {
-    messagesProcessed: new client.Counter({
-      name: 'kafka_hooks_messages_processed_total',
-      help: 'Total number of messages successfully processed',
-      labelNames: ['topic', 'status'], // status => 'success', 'failed'
-      registers: [registry]
-    }),
-
-    messagesInFlight: new client.Gauge({
-      name: 'kafka_hooks_messages_in_flight',
-      help: 'Number of messages currently being processed',
-      labelNames: ['topic'],
-      registers: [registry]
-    }),
-
-    httpRequestDuration: new client.Histogram({
-      name: 'kafka_hooks_http_request_duration_seconds',
-      help: 'HTTP request duration for webhook deliveries',
-      labelNames: ['topic', 'method', 'status_code'],
-      buckets: [0.1, 0.5, 1, 2, 5, 10],
-      registers: [registry]
-    }),
-
-    dlqMessages: new client.Counter({
-      name: 'kafka_hooks_dlq_messages_total',
-      help: 'Total number of messages sent to the DLQ (Dead Letter Queue)',
-      labelNames: ['topic', 'reason'],
-      registers: [registry]
-    })
-  }
-}
+import { initMetrics } from './metrics.js'
 
 export async function processMessage (logger, dlqProducer, mappings, message, metrics) {
   const topic = message.topic

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,10 +18,51 @@ import {
   queryStringHeader
 } from './definitions.js'
 
-export async function processMessage (logger, dlqProducer, mappings, message) {
+function initMetrics (prometheus) {
+  if (!prometheus?.registry || !prometheus?.client) return null
+  const { client, registry } = prometheus
+
+  return {
+    messagesProcessed: new client.Counter({
+      name: 'kafka_hooks_messages_processed_total',
+      help: 'Total number of messages successfully processed',
+      labelNames: ['topic', 'status'], // status => 'success', 'failed'
+      registers: [registry]
+    }),
+
+    messagesInFlight: new client.Gauge({
+      name: 'kafka_hooks_messages_in_flight',
+      help: 'Number of messages currently being processed',
+      labelNames: ['topic'],
+      registers: [registry]
+    }),
+
+    httpRequestDuration: new client.Histogram({
+      name: 'kafka_hooks_http_request_duration_seconds',
+      help: 'HTTP request duration for webhook deliveries',
+      labelNames: ['topic', 'method', 'status_code'],
+      buckets: [0.1, 0.5, 1, 2, 5, 10],
+      registers: [registry]
+    }),
+
+    dlqMessages: new client.Counter({
+      name: 'kafka_hooks_dlq_messages_total',
+      help: 'Total number of messages sent to the DLQ (Dead Letter Queue)',
+      labelNames: ['topic', 'reason'],
+      registers: [registry]
+    })
+  }
+}
+
+export async function processMessage (logger, dlqProducer, mappings, message, metrics) {
   const topic = message.topic
   const value = message.value
   const { url, dlq, method, retryDelay, headers: protoHeaders, retries, includeAttemptInRequests } = mappings[topic]
+
+  if (metrics) {
+    metrics.messagesInFlight.inc({ topic })
+  }
+
   const headers = {
     ...protoHeaders,
     ...Object.fromEntries(message.headers),
@@ -30,6 +71,8 @@ export async function processMessage (logger, dlqProducer, mappings, message) {
 
   // Perform the delivery
   const errors = []
+  let lastStatusCode = null
+
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
       if (includeAttemptInRequests) {
@@ -38,7 +81,7 @@ export async function processMessage (logger, dlqProducer, mappings, message) {
 
       headers['content-length'] = Buffer.byteLength(value)
 
-      const requestedAt = new Date()
+      const requestedAt = Date.now()
       const {
         statusCode,
         headers: responseHeaders,
@@ -49,14 +92,30 @@ export async function processMessage (logger, dlqProducer, mappings, message) {
         body: value
       })
 
+      lastStatusCode = statusCode
+
+      if (metrics) {
+        const duration = (Date.now() - requestedAt) / 1000
+        metrics.httpRequestDuration.observe(
+          { topic, method, status_code: statusCode },
+          duration
+        )
+      }
+
       // Success, nothing else to do
       if (statusCode < BAD_REQUEST) {
         await body.dump()
+
+        if (metrics) {
+          metrics.messagesProcessed.inc({ topic, status: 'success' })
+          metrics.messagesInFlight.dec({ topic })
+        }
+
         return
       }
 
       const error = new HttpError(statusCode, 'Webhook replied with an error', {
-        requestedAt: requestedAt.toISOString(),
+        requestedAt: new Date(requestedAt).toISOString(),
         attempt,
         headers: responseHeaders,
         /* c8 ignore next */
@@ -87,6 +146,18 @@ export async function processMessage (logger, dlqProducer, mappings, message) {
       offset: message.offset.toString(),
       errors: errors.map(e => e.serialize(true)),
       retries
+    }
+  }
+
+  if (metrics) {
+    metrics.messagesProcessed.inc({ topic, status: 'failed' })
+    metrics.messagesInFlight.dec({ topic })
+
+    if (dlq) {
+      metrics.dlqMessages.inc({
+        topic,
+        reason: lastStatusCode ? `http_${lastStatusCode}` : 'network_error'
+      })
     }
   }
 
@@ -215,6 +286,7 @@ export async function setupKafka (server, configuration) {
   server.log.info(`Kafka consumer started with concurrency ${configuration.kafka.concurrency} ...`)
 
   const responseProcessor = createResponseProcessor(server.log, pendingRequests)
+  const metrics = initMetrics(globalThis.platformatic?.prometheus)
 
   forEach(
     stream,
@@ -222,7 +294,7 @@ export async function setupKafka (server, configuration) {
       if (responseMappings[message.topic]) {
         return responseProcessor(message)
       } else {
-        return processMessage(server.log, dlqProducer, topicsMappings, message)
+        return processMessage(server.log, dlqProducer, topicsMappings, message, metrics)
       }
     },
     /* c8 ignore next 8 */

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -72,7 +72,6 @@ export async function processMessage (logger, dlqProducer, mappings, message, me
         await body.dump()
 
         if (metrics) {
-          metrics.messagesProcessed.inc({ topic, status: 'success' })
           metrics.messagesInFlight.dec({ topic })
         }
 
@@ -115,7 +114,6 @@ export async function processMessage (logger, dlqProducer, mappings, message, me
   }
 
   if (metrics) {
-    metrics.messagesProcessed.inc({ topic, status: 'failed' })
     metrics.messagesInFlight.dec({ topic })
 
     if (dlq) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "neostandard": "^0.12.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
+    "prom-client": "^15.1.3",
     "prettier": "^3.5.3",
     "wait-on": "^8.0.3"
   },

--- a/test/fixtures/kafka-monitor.js
+++ b/test/fixtures/kafka-monitor.js
@@ -18,7 +18,9 @@ export async function createMonitor (valueDeserializer = safeJsonDeserializer) {
     maxWaitTime: 500,
     deserializers: {
       value: valueDeserializer
-    }
+    },
+    /* c8 ignore next */
+    metrics: globalThis.platformatic?.prometheus
   })
 
   const topics = ['plt-kafka-hooks-success', 'plt-kafka-hooks-fail', 'plt-kafka-hooks-retry', defaultDlqTopic]

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,217 @@
+import { test } from 'node:test'
+import { strictEqual, deepStrictEqual, ok } from 'node:assert'
+import { initMetrics } from '../lib/metrics.js'
+
+function createMockPrometheusClient () {
+  const registry = {
+    register: () => {},
+    clear: () => {},
+    metrics: () => 'mock metrics',
+    getSingleMetric: () => null
+  }
+
+  const client = {
+    Counter: class MockCounter {
+      constructor (config) {
+        this.config = config
+        this.values = new Map()
+      }
+
+      inc (labels = {}, value = 1) {
+        const key = JSON.stringify(labels)
+        this.values.set(key, (this.values.get(key) || 0) + value)
+      }
+
+      get (labels = {}) {
+        const key = JSON.stringify(labels)
+        return { value: this.values.get(key) || 0 }
+      }
+    },
+
+    Gauge: class MockGauge {
+      constructor (config) {
+        this.config = config
+        this.values = new Map()
+      }
+
+      inc (labels = {}, value = 1) {
+        const key = JSON.stringify(labels)
+        this.values.set(key, (this.values.get(key) || 0) + value)
+      }
+
+      dec (labels = {}, value = 1) {
+        const key = JSON.stringify(labels)
+        this.values.set(key, (this.values.get(key) || 0) - value)
+      }
+
+      set (labels = {}, value) {
+        const key = JSON.stringify(labels)
+        this.values.set(key, value)
+      }
+
+      get (labels = {}) {
+        const key = JSON.stringify(labels)
+        return { value: this.values.get(key) || 0 }
+      }
+    },
+
+    Histogram: class MockHistogram {
+      constructor (config) {
+        this.config = config
+        this.observations = []
+      }
+
+      observe (labels = {}, value) {
+        this.observations.push({ labels, value })
+      }
+
+      get (labels = {}) {
+        return {
+          buckets: new Map(),
+          count: this.observations.length,
+          sum: this.observations.reduce((sum, obs) => sum + obs.value, 0)
+        }
+      }
+    }
+  }
+
+  return { registry, client }
+}
+
+test('initMetrics should return null when prometheus is not provided', async () => {
+  const result = initMetrics()
+  strictEqual(result, null)
+})
+
+test('initMetrics should return null when prometheus is null', async () => {
+  const result = initMetrics(null)
+  strictEqual(result, null)
+})
+
+test('initMetrics should return null when prometheus.registry is missing', async () => {
+  const prometheus = { client: {} }
+  const result = initMetrics(prometheus)
+  strictEqual(result, null)
+})
+
+test('initMetrics should return null when prometheus.client is missing', async () => {
+  const prometheus = { registry: {} }
+  const result = initMetrics(prometheus)
+  strictEqual(result, null)
+})
+
+test('initMetrics should return metrics object when prometheus is properly configured', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  ok(metrics, 'Metrics object should be created')
+  ok(metrics.messagesProcessed, 'messagesProcessed metric should exist')
+  ok(metrics.messagesInFlight, 'messagesInFlight metric should exist')
+  ok(metrics.httpRequestDuration, 'httpRequestDuration metric should exist')
+  ok(metrics.dlqMessages, 'dlqMessages metric should exist')
+})
+
+test('messagesProcessed should be configured as Counter with correct properties', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  const counter = metrics.messagesProcessed
+  strictEqual(counter.config.name, 'kafka_hooks_messages_processed_total')
+  strictEqual(counter.config.help, 'Total number of messages successfully processed')
+  deepStrictEqual(counter.config.labelNames, ['topic', 'status'])
+  deepStrictEqual(counter.config.registers, [prometheus.registry])
+})
+
+test('messagesInFlight should be configured as Gauge with correct properties', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  const gauge = metrics.messagesInFlight
+  strictEqual(gauge.config.name, 'kafka_hooks_messages_in_flight')
+  strictEqual(gauge.config.help, 'Number of messages currently being processed')
+  deepStrictEqual(gauge.config.labelNames, ['topic'])
+  deepStrictEqual(gauge.config.registers, [prometheus.registry])
+})
+
+test('httpRequestDuration should be configured as Histogram with correct properties', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  const histogram = metrics.httpRequestDuration
+  strictEqual(histogram.config.name, 'kafka_hooks_http_request_duration_seconds')
+  strictEqual(histogram.config.help, 'HTTP request duration for webhook deliveries')
+  deepStrictEqual(histogram.config.labelNames, ['topic', 'method', 'status_code'])
+  deepStrictEqual(histogram.config.buckets, [0.1, 0.5, 1, 2, 5, 10])
+  deepStrictEqual(histogram.config.registers, [prometheus.registry])
+})
+
+test('dlqMessages should be configured as Counter with correct properties', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  const counter = metrics.dlqMessages
+  strictEqual(counter.config.name, 'kafka_hooks_dlq_messages_total')
+  strictEqual(counter.config.help, 'Total number of messages sent to the DLQ (Dead Letter Queue)')
+  deepStrictEqual(counter.config.labelNames, ['topic', 'reason'])
+  deepStrictEqual(counter.config.registers, [prometheus.registry])
+})
+
+test('metrics should be functional - Counter operations', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'success' })
+  metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'success' }, 2)
+  metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'failed' })
+
+  strictEqual(metrics.messagesProcessed.get({ topic: 'test-topic', status: 'success' }).value, 3)
+  strictEqual(metrics.messagesProcessed.get({ topic: 'test-topic', status: 'failed' }).value, 1)
+
+  metrics.dlqMessages.inc({ topic: 'test-topic', reason: 'http_500' })
+  metrics.dlqMessages.inc({ topic: 'test-topic', reason: 'network_error' }, 3)
+
+  strictEqual(metrics.dlqMessages.get({ topic: 'test-topic', reason: 'http_500' }).value, 1)
+  strictEqual(metrics.dlqMessages.get({ topic: 'test-topic', reason: 'network_error' }).value, 3)
+})
+
+test('metrics should be functional - Gauge operations', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  metrics.messagesInFlight.inc({ topic: 'test-topic' })
+  metrics.messagesInFlight.inc({ topic: 'test-topic' }, 2)
+  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 3)
+
+  metrics.messagesInFlight.dec({ topic: 'test-topic' })
+  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 2)
+
+  metrics.messagesInFlight.set({ topic: 'test-topic' }, 5)
+  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 5)
+})
+
+test('metrics should be functional - Histogram operations', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '200' }, 0.5)
+  metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '200' }, 1.2)
+  metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '500' }, 2.1)
+
+  const result = metrics.httpRequestDuration.get({ topic: 'test-topic', method: 'POST', status_code: '200' })
+  strictEqual(result.count, 3) // Total observations
+  strictEqual(result.sum, 3.8) // Sum of all observations (0.5 + 1.2 + 2.1)
+})
+
+test('metrics should handle different label combinations', async () => {
+  const prometheus = createMockPrometheusClient()
+  const metrics = initMetrics(prometheus)
+
+  metrics.messagesProcessed.inc({ topic: 'topic-1', status: 'success' })
+  metrics.messagesProcessed.inc({ topic: 'topic-2', status: 'success' })
+  metrics.messagesProcessed.inc({ topic: 'topic-1', status: 'failed' })
+
+  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-1', status: 'success' }).value, 1)
+  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-2', status: 'success' }).value, 1)
+  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-1', status: 'failed' }).value, 1)
+  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-2', status: 'failed' }).value, 0)
+})

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,82 +1,7 @@
 import { test } from 'node:test'
 import { strictEqual, deepStrictEqual, ok } from 'node:assert'
 import { initMetrics } from '../lib/metrics.js'
-
-function createMockPrometheusClient () {
-  const registry = {
-    register: () => {},
-    clear: () => {},
-    metrics: () => 'mock metrics',
-    getSingleMetric: () => null
-  }
-
-  const client = {
-    Counter: class MockCounter {
-      constructor (config) {
-        this.config = config
-        this.values = new Map()
-      }
-
-      inc (labels = {}, value = 1) {
-        const key = JSON.stringify(labels)
-        this.values.set(key, (this.values.get(key) || 0) + value)
-      }
-
-      get (labels = {}) {
-        const key = JSON.stringify(labels)
-        return { value: this.values.get(key) || 0 }
-      }
-    },
-
-    Gauge: class MockGauge {
-      constructor (config) {
-        this.config = config
-        this.values = new Map()
-      }
-
-      inc (labels = {}, value = 1) {
-        const key = JSON.stringify(labels)
-        this.values.set(key, (this.values.get(key) || 0) + value)
-      }
-
-      dec (labels = {}, value = 1) {
-        const key = JSON.stringify(labels)
-        this.values.set(key, (this.values.get(key) || 0) - value)
-      }
-
-      set (labels = {}, value) {
-        const key = JSON.stringify(labels)
-        this.values.set(key, value)
-      }
-
-      get (labels = {}) {
-        const key = JSON.stringify(labels)
-        return { value: this.values.get(key) || 0 }
-      }
-    },
-
-    Histogram: class MockHistogram {
-      constructor (config) {
-        this.config = config
-        this.observations = []
-      }
-
-      observe (labels = {}, value) {
-        this.observations.push({ labels, value })
-      }
-
-      get (labels = {}) {
-        return {
-          buckets: new Map(),
-          count: this.observations.length,
-          sum: this.observations.reduce((sum, obs) => sum + obs.value, 0)
-        }
-      }
-    }
-  }
-
-  return { registry, client }
-}
+import promClient from 'prom-client'
 
 test('initMetrics should return null when prometheus is not provided', async () => {
   const result = initMetrics()
@@ -89,19 +14,20 @@ test('initMetrics should return null when prometheus is null', async () => {
 })
 
 test('initMetrics should return null when prometheus.registry is missing', async () => {
-  const prometheus = { client: {} }
+  const prometheus = { client: promClient }
   const result = initMetrics(prometheus)
   strictEqual(result, null)
 })
 
 test('initMetrics should return null when prometheus.client is missing', async () => {
-  const prometheus = { registry: {} }
+  const prometheus = { registry: new promClient.Registry() }
   const result = initMetrics(prometheus)
   strictEqual(result, null)
 })
 
 test('initMetrics should return metrics object when prometheus is properly configured', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   ok(metrics, 'Metrics object should be created')
@@ -112,106 +38,178 @@ test('initMetrics should return metrics object when prometheus is properly confi
 })
 
 test('messagesProcessed should be configured as Counter with correct properties', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   const counter = metrics.messagesProcessed
-  strictEqual(counter.config.name, 'kafka_hooks_messages_processed_total')
-  strictEqual(counter.config.help, 'Total number of messages successfully processed')
-  deepStrictEqual(counter.config.labelNames, ['topic', 'status'])
-  deepStrictEqual(counter.config.registers, [prometheus.registry])
+  strictEqual(counter.name, 'kafka_hooks_messages_processed_total')
+  strictEqual(counter.help, 'Total number of messages successfully processed')
+  deepStrictEqual(counter.labelNames, ['topic', 'status'])
 })
 
 test('messagesInFlight should be configured as Gauge with correct properties', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   const gauge = metrics.messagesInFlight
-  strictEqual(gauge.config.name, 'kafka_hooks_messages_in_flight')
-  strictEqual(gauge.config.help, 'Number of messages currently being processed')
-  deepStrictEqual(gauge.config.labelNames, ['topic'])
-  deepStrictEqual(gauge.config.registers, [prometheus.registry])
+  strictEqual(gauge.name, 'kafka_hooks_messages_in_flight')
+  strictEqual(gauge.help, 'Number of messages currently being processed')
+  deepStrictEqual(gauge.labelNames, ['topic'])
 })
 
 test('httpRequestDuration should be configured as Histogram with correct properties', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   const histogram = metrics.httpRequestDuration
-  strictEqual(histogram.config.name, 'kafka_hooks_http_request_duration_seconds')
-  strictEqual(histogram.config.help, 'HTTP request duration for webhook deliveries')
-  deepStrictEqual(histogram.config.labelNames, ['topic', 'method', 'status_code'])
-  deepStrictEqual(histogram.config.buckets, [0.1, 0.5, 1, 2, 5, 10])
-  deepStrictEqual(histogram.config.registers, [prometheus.registry])
+  strictEqual(histogram.name, 'kafka_hooks_http_request_duration_seconds')
+  strictEqual(histogram.help, 'HTTP request duration for webhook deliveries')
+  deepStrictEqual(histogram.labelNames, ['topic', 'method', 'status_code'])
+  deepStrictEqual(histogram.buckets, [0.1, 0.5, 1, 2, 5, 10])
 })
 
 test('dlqMessages should be configured as Counter with correct properties', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   const counter = metrics.dlqMessages
-  strictEqual(counter.config.name, 'kafka_hooks_dlq_messages_total')
-  strictEqual(counter.config.help, 'Total number of messages sent to the DLQ (Dead Letter Queue)')
-  deepStrictEqual(counter.config.labelNames, ['topic', 'reason'])
-  deepStrictEqual(counter.config.registers, [prometheus.registry])
+  strictEqual(counter.name, 'kafka_hooks_dlq_messages_total')
+  strictEqual(counter.help, 'Total number of messages sent to the DLQ (Dead Letter Queue)')
+  deepStrictEqual(counter.labelNames, ['topic', 'reason'])
 })
 
 test('metrics should be functional - Counter operations', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'success' })
   metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'success' }, 2)
   metrics.messagesProcessed.inc({ topic: 'test-topic', status: 'failed' })
 
-  strictEqual(metrics.messagesProcessed.get({ topic: 'test-topic', status: 'success' }).value, 3)
-  strictEqual(metrics.messagesProcessed.get({ topic: 'test-topic', status: 'failed' }).value, 1)
+  // Get metric values from registry
+  const registryMetrics = await registry.getMetricsAsJSON()
+  const messagesProcessedMetric = registryMetrics.find(m => m.name === 'kafka_hooks_messages_processed_total')
+
+  const successValue = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'test-topic' && v.labels.status === 'success'
+  ).value
+  const failedValue = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'test-topic' && v.labels.status === 'failed'
+  ).value
+
+  strictEqual(successValue, 3)
+  strictEqual(failedValue, 1)
 
   metrics.dlqMessages.inc({ topic: 'test-topic', reason: 'http_500' })
   metrics.dlqMessages.inc({ topic: 'test-topic', reason: 'network_error' }, 3)
 
-  strictEqual(metrics.dlqMessages.get({ topic: 'test-topic', reason: 'http_500' }).value, 1)
-  strictEqual(metrics.dlqMessages.get({ topic: 'test-topic', reason: 'network_error' }).value, 3)
+  const updatedMetrics = await registry.getMetricsAsJSON()
+  const dlqMetric = updatedMetrics.find(m => m.name === 'kafka_hooks_dlq_messages_total')
+
+  const http500Value = dlqMetric.values.find(v =>
+    v.labels.topic === 'test-topic' && v.labels.reason === 'http_500'
+  ).value
+  const networkErrorValue = dlqMetric.values.find(v =>
+    v.labels.topic === 'test-topic' && v.labels.reason === 'network_error'
+  ).value
+
+  strictEqual(http500Value, 1)
+  strictEqual(networkErrorValue, 3)
 })
 
 test('metrics should be functional - Gauge operations', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   metrics.messagesInFlight.inc({ topic: 'test-topic' })
   metrics.messagesInFlight.inc({ topic: 'test-topic' }, 2)
-  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 3)
+
+  let registryMetrics = await registry.getMetricsAsJSON()
+  let gaugeMetric = registryMetrics.find(m => m.name === 'kafka_hooks_messages_in_flight')
+  let value = gaugeMetric.values.find(v => v.labels.topic === 'test-topic').value
+  strictEqual(value, 3)
 
   metrics.messagesInFlight.dec({ topic: 'test-topic' })
-  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 2)
+
+  registryMetrics = await registry.getMetricsAsJSON()
+  gaugeMetric = registryMetrics.find(m => m.name === 'kafka_hooks_messages_in_flight')
+  value = gaugeMetric.values.find(v => v.labels.topic === 'test-topic').value
+  strictEqual(value, 2)
 
   metrics.messagesInFlight.set({ topic: 'test-topic' }, 5)
-  strictEqual(metrics.messagesInFlight.get({ topic: 'test-topic' }).value, 5)
+
+  registryMetrics = await registry.getMetricsAsJSON()
+  gaugeMetric = registryMetrics.find(m => m.name === 'kafka_hooks_messages_in_flight')
+  value = gaugeMetric.values.find(v => v.labels.topic === 'test-topic').value
+  strictEqual(value, 5)
 })
 
 test('metrics should be functional - Histogram operations', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '200' }, 0.5)
   metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '200' }, 1.2)
   metrics.httpRequestDuration.observe({ topic: 'test-topic', method: 'POST', status_code: '500' }, 2.1)
 
-  const result = metrics.httpRequestDuration.get({ topic: 'test-topic', method: 'POST', status_code: '200' })
-  strictEqual(result.count, 3) // Total observations
-  strictEqual(result.sum, 3.8) // Sum of all observations (0.5 + 1.2 + 2.1)
+  const registryMetrics = await registry.getMetricsAsJSON()
+  const histogramMetric = registryMetrics.find(m => m.name === 'kafka_hooks_http_request_duration_seconds')
+
+  const countValue = histogramMetric.values.find(v =>
+    v.labels.topic === 'test-topic' &&
+    v.labels.method === 'POST' &&
+    v.labels.status_code === '200' &&
+    v.metricName === 'kafka_hooks_http_request_duration_seconds_count'
+  ).value
+
+  const sumValue = histogramMetric.values.find(v =>
+    v.labels.topic === 'test-topic' &&
+    v.labels.method === 'POST' &&
+    v.labels.status_code === '200' &&
+    v.metricName === 'kafka_hooks_http_request_duration_seconds_sum'
+  ).value
+
+  strictEqual(countValue, 2) // Two observations for 200 status code
+  strictEqual(sumValue, 1.7) // 0.5 + 1.2 = 1.7
 })
 
 test('metrics should handle different label combinations', async () => {
-  const prometheus = createMockPrometheusClient()
+  const registry = new promClient.Registry()
+  const prometheus = { registry, client: promClient }
   const metrics = initMetrics(prometheus)
 
   metrics.messagesProcessed.inc({ topic: 'topic-1', status: 'success' })
   metrics.messagesProcessed.inc({ topic: 'topic-2', status: 'success' })
   metrics.messagesProcessed.inc({ topic: 'topic-1', status: 'failed' })
 
-  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-1', status: 'success' }).value, 1)
-  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-2', status: 'success' }).value, 1)
-  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-1', status: 'failed' }).value, 1)
-  strictEqual(metrics.messagesProcessed.get({ topic: 'topic-2', status: 'failed' }).value, 0)
+  const registryMetrics = await registry.getMetricsAsJSON()
+  const messagesProcessedMetric = registryMetrics.find(m => m.name === 'kafka_hooks_messages_processed_total')
+
+  const topic1Success = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'topic-1' && v.labels.status === 'success'
+  )?.value || 0
+
+  const topic2Success = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'topic-2' && v.labels.status === 'success'
+  )?.value || 0
+
+  const topic1Failed = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'topic-1' && v.labels.status === 'failed'
+  )?.value || 0
+
+  const topic2Failed = messagesProcessedMetric.values.find(v =>
+    v.labels.topic === 'topic-2' && v.labels.status === 'failed'
+  )?.value || 0
+
+  strictEqual(topic1Success, 1)
+  strictEqual(topic2Success, 1)
+  strictEqual(topic1Failed, 1)
+  strictEqual(topic2Failed, 0)
 })

--- a/test/processMessage.test.js
+++ b/test/processMessage.test.js
@@ -1,46 +1,14 @@
 import { stringDeserializer, jsonDeserializer, Consumer, Producer, stringSerializer, jsonSerializer } from '@platformatic/kafka'
 import { randomUUID } from 'node:crypto'
-import { once } from 'node:events'
 import { test } from 'node:test'
 import { strictEqual, ok } from 'node:assert'
 import { processMessage } from '../lib/plugin.js'
 import { defaultDlqTopic } from '../lib/definitions.js'
 import { MockAgent, setGlobalDispatcher, Agent } from 'undici'
+import promClient from 'prom-client'
+import { initMetrics } from '../lib/metrics.js'
 
-function createMockMetrics () {
-  const counters = {}
-  const gauges = {}
-  const histograms = {}
-
-  return {
-    messagesInFlight: {
-      inc: ({ topic }) => {
-        gauges[topic] = (gauges[topic] || 0) + 1
-      },
-      dec: ({ topic }) => {
-        gauges[topic] = (gauges[topic] || 0) - 1
-      },
-      getValue: (topic) => gauges[topic] || 0
-    },
-    httpRequestDuration: {
-      observe: ({ topic, method, code }, duration) => {
-        const key = `${topic}-${method}-${code}`
-        if (!histograms[key]) {
-          histograms[key] = []
-        }
-        histograms[key].push(duration)
-      },
-      getObservations: (topic, method, code) => histograms[`${topic}-${method}-${code}`] || []
-    },
-    dlqMessages: {
-      inc: ({ topic, reason }) => {
-        const key = `dlq-${topic}-${reason}`
-        counters[key] = (counters[key] || 0) + 1
-      },
-      getCount: (topic, reason) => counters[`dlq-${topic}-${reason}`] || 0
-    }
-  }
-}
+const metrics = initMetrics({ client: promClient, registry: promClient.register })
 
 async function createDlqProducer () {
   const producer = new Producer({
@@ -101,66 +69,34 @@ function createMockLogger () {
   }
 }
 
-test('processMessage should send to DLQ with http status code reason when request returns error status', async t => {
-  const metrics = createMockMetrics()
-  const logger = createMockLogger()
-  const dlqProducer = await createDlqProducer()
-  t.after(() => dlqProducer.close())
+// Helper functions to get metric values
+function getGaugeValue (gaugeName, labels) {
+  const metric = promClient.register.getSingleMetric(gaugeName)
+  if (!metric) return 0
 
-  const { stream } = await createDlqConsumer(t)
+  const result = metric.get()
+  if (!result || !result.values || !Array.isArray(result.values)) return 0
 
-  const mockAgent = new MockAgent()
-  mockAgent.disableNetConnect()
-  setGlobalDispatcher(mockAgent)
-
-  t.after(async () => {
-    await mockAgent.close()
-    setGlobalDispatcher(new Agent())
+  const match = result.values.find(v => {
+    return Object.keys(labels).every(key => v.labels[key] === labels[key])
   })
+  return match ? match.value : 0
+}
 
-  const mockPool = mockAgent.get('http://127.0.0.1:8080')
-  mockPool
-    .intercept({
-      path: '/error',
-      method: 'POST'
-    })
-    .reply(500, { error: 'Internal Server Error' }, {
-      'content-type': 'application/json'
-    })
+function getCounterValue (counterName, labels) {
+  const metric = promClient.register.getSingleMetric(counterName)
+  if (!metric) return 0
 
-  const mappings = {
-    'test-topic': {
-      url: 'http://127.0.0.1:8080/error',
-      dlq: defaultDlqTopic,
-      method: 'POST',
-      retryDelay: 100,
-      headers: {},
-      retries: 2,
-      includeAttemptInRequests: true
-    }
-  }
+  const result = metric.get()
+  if (!result || !result.values || !Array.isArray(result.values)) return 0
 
-  const message = createMockMessage('test-topic', 'test-value', 'test-key')
-
-  await processMessage(logger, dlqProducer, mappings, message, metrics)
-
-  const [dlqMessage] = await once(stream, 'data')
-
-  strictEqual(metrics.messagesInFlight.getValue('test-topic'), 0)
-
-  strictEqual(metrics.dlqMessages.getCount('test-topic', 'http_500'), 1)
-  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 0)
-
-  strictEqual(dlqMessage.topic, defaultDlqTopic)
-  strictEqual(dlqMessage.value.retries, 2)
-  strictEqual(dlqMessage.value.errors.length, 2)
-  strictEqual(Buffer.from(dlqMessage.value.value, 'base64').toString(), 'test-value')
-
-  mockAgent.assertNoPendingInterceptors()
-})
+  const match = result.values.find(v => {
+    return Object.keys(labels).every(key => v.labels[key] === labels[key])
+  })
+  return match ? match.value : 0
+}
 
 test('processMessage should update success metrics when request succeeds', async t => {
-  const metrics = createMockMetrics()
   const logger = createMockLogger()
   const dlqProducer = await createDlqProducer()
   t.after(() => dlqProducer.close())
@@ -196,53 +132,16 @@ test('processMessage should update success metrics when request succeeds', async
 
   const message = createMockMessage('test-topic', 'test-value', 'test-key')
 
-  strictEqual(metrics.messagesInFlight.getValue('test-topic'), 0)
+  const initialInflightCount = getGaugeValue('kafka_hooks_messages_in_flight', { topic: 'test-topic' })
   await processMessage(logger, dlqProducer, mappings, message, metrics)
 
-  strictEqual(metrics.messagesInFlight.getValue('test-topic'), 0) // Should be decremented back to 0
-
-  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 0)
+  strictEqual(getGaugeValue('kafka_hooks_messages_in_flight', { topic: 'test-topic' }), initialInflightCount)
+  strictEqual(getCounterValue('kafka_hooks_dlq_messages_total', { topic: 'test-topic', reason: 'network_error' }), 0)
 
   mockAgent.assertNoPendingInterceptors()
 })
 
-test('processMessage should handle failed requests and update metrics', async t => {
-  const metrics = createMockMetrics()
-  const logger = createMockLogger()
-  const dlqProducer = await createDlqProducer()
-  t.after(() => dlqProducer.close())
-
-  const { stream } = await createDlqConsumer(t)
-
-  const mappings = {
-    'test-topic': {
-      url: 'http://127.0.0.1:1/fail', // Non-existent server
-      dlq: defaultDlqTopic,
-      method: 'POST',
-      retryDelay: 100,
-      headers: {},
-      retries: 2,
-      includeAttemptInRequests: true
-    }
-  }
-
-  const message = createMockMessage('test-topic', 'test-value', 'test-key')
-
-  await processMessage(logger, dlqProducer, mappings, message, metrics)
-
-  const [dlqMessage] = await once(stream, 'data')
-
-  strictEqual(metrics.messagesInFlight.getValue('test-topic'), 0)
-  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 1)
-
-  strictEqual(dlqMessage.topic, defaultDlqTopic)
-  strictEqual(dlqMessage.value.retries, 2)
-  strictEqual(dlqMessage.value.errors.length, 2)
-  strictEqual(Buffer.from(dlqMessage.value.value, 'base64').toString(), 'test-value')
-})
-
 test('processMessage should not send to DLQ when dlq is false', async t => {
-  const metrics = createMockMetrics()
   const logger = createMockLogger()
   const dlqProducer = await createDlqProducer()
   t.after(() => dlqProducer.close())
@@ -268,9 +167,11 @@ test('processMessage should not send to DLQ when dlq is false', async t => {
     dlqMessageReceived = true
   })
 
+  const initialNetworkErrorCount = getCounterValue('kafka_hooks_dlq_messages_total', { topic: 'test-topic', reason: 'network_error' })
+
   await processMessage(logger, dlqProducer, mappings, message, metrics)
 
-  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 0)
+  strictEqual(getCounterValue('kafka_hooks_dlq_messages_total', { topic: 'test-topic', reason: 'network_error' }), initialNetworkErrorCount)
   strictEqual(dlqMessageReceived, false)
 
   const logs = logger.getLogs()

--- a/test/processMessage.test.js
+++ b/test/processMessage.test.js
@@ -1,0 +1,188 @@
+import { sleep, stringDeserializer, jsonDeserializer, Consumer, Producer, stringSerializer, jsonSerializer } from '@platformatic/kafka'
+import { randomUUID } from 'node:crypto'
+import { once } from 'node:events'
+import { test } from 'node:test'
+import { strictEqual, ok } from 'node:assert'
+import { processMessage } from '../lib/plugin.js'
+import { defaultDlqTopic } from '../lib/definitions.js'
+
+// Mock metrics implementation
+function createMockMetrics () {
+  const counters = {}
+  const gauges = {}
+  const histograms = {}
+
+  return {
+    messagesProcessed: {
+      inc: ({ topic, status }) => {
+        const key = `${topic}-${status}`
+        counters[key] = (counters[key] || 0) + 1
+      },
+      getCount: (topic, status) => counters[`${topic}-${status}`] || 0
+    },
+    messagesInFlight: {
+      inc: ({ topic }) => {
+        gauges[topic] = (gauges[topic] || 0) + 1
+      },
+      dec: ({ topic }) => {
+        gauges[topic] = (gauges[topic] || 0) - 1
+      },
+      getValue: (topic) => gauges[topic] || 0
+    },
+    httpRequestDuration: {
+      observe: ({ topic, method, code }, duration) => {
+        const key = `${topic}-${method}-${code}`
+        if (!histograms[key]) {
+          histograms[key] = []
+        }
+        histograms[key].push(duration)
+      },
+      getObservations: (topic, method, code) => histograms[`${topic}-${method}-${code}`] || []
+    },
+    dlqMessages: {
+      inc: ({ topic, reason }) => {
+        const key = `dlq-${topic}-${reason}`
+        counters[key] = (counters[key] || 0) + 1
+      },
+      getCount: (topic, reason) => counters[`dlq-${topic}-${reason}`] || 0
+    }
+  }
+}
+
+async function createDlqProducer () {
+  const producer = new Producer({
+    bootstrapBrokers: ['localhost:9092'],
+    serializers: {
+      key: stringSerializer,
+      value: jsonSerializer,
+      headerKey: stringSerializer,
+      headerValue: stringSerializer
+    }
+  })
+
+  return producer
+}
+
+async function createDlqConsumer (t, topics = [defaultDlqTopic]) {
+  const consumer = new Consumer({
+    groupId: randomUUID(),
+    bootstrapBrokers: ['localhost:9092'],
+    maxWaitTime: 500,
+    deserializers: {
+      key: stringDeserializer,
+      value: jsonDeserializer,
+      headerKey: stringDeserializer,
+      headerValue: stringDeserializer
+    }
+  })
+
+  await consumer.metadata({ topics, autocreateTopics: true })
+  const stream = await consumer.consume({ topics })
+
+  t.after(() => consumer.close(true))
+
+  return { consumer, stream }
+}
+
+function createMockMessage (topic, value, key = '', headers = {}) {
+  return {
+    topic,
+    value: Buffer.isBuffer(value) ? value : Buffer.from(value),
+    key: Buffer.from(key),
+    headers: new Map(Object.entries(headers)),
+    partition: 0,
+    offset: BigInt(Date.now())
+  }
+}
+
+function createMockLogger () {
+  const logs = []
+  return {
+    error: (obj, msg) => logs.push({ level: 'error', obj, msg }),
+    warn: (obj, msg) => logs.push({ level: 'warn', obj, msg }),
+    info: (obj, msg) => logs.push({ level: 'info', obj, msg }),
+    getLogs: () => logs,
+    clearLogs: () => {
+      logs.length = 0
+    }
+  }
+}
+
+test('processMessage should handle failed requests and update metrics', async t => {
+  const metrics = createMockMetrics()
+  const logger = createMockLogger()
+  const dlqProducer = await createDlqProducer()
+  t.after(() => dlqProducer.close())
+
+  const { stream } = await createDlqConsumer(t)
+
+  const mappings = {
+    'test-topic': {
+      url: 'http://127.0.0.1:1/fail', // Non-existent server
+      dlq: defaultDlqTopic,
+      method: 'POST',
+      retryDelay: 100,
+      headers: {},
+      retries: 2,
+      includeAttemptInRequests: true
+    }
+  }
+
+  const message = createMockMessage('test-topic', 'test-value', 'test-key')
+
+  await processMessage(logger, dlqProducer, mappings, message, metrics)
+
+  // Wait for DLQ message
+  const [dlqMessage] = await once(stream, 'data')
+
+  // Verify failure metrics
+  strictEqual(metrics.messagesProcessed.getCount('test-topic', 'failed'), 1)
+  strictEqual(metrics.messagesInFlight.getValue('test-topic'), 0)
+  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 1)
+
+  // Verify DLQ message content
+  strictEqual(dlqMessage.topic, defaultDlqTopic)
+  strictEqual(dlqMessage.value.retries, 2)
+  strictEqual(dlqMessage.value.errors.length, 2)
+  strictEqual(Buffer.from(dlqMessage.value.value, 'base64').toString(), 'test-value')
+})
+
+test('processMessage should not send to DLQ when dlq is false', async t => {
+  const metrics = createMockMetrics()
+  const logger = createMockLogger()
+  const dlqProducer = await createDlqProducer()
+  t.after(() => dlqProducer.close())
+
+  const { stream } = await createDlqConsumer(t)
+
+  const mappings = {
+    'test-topic': {
+      url: 'http://127.0.0.1:1/fail', // Non-existent server
+      dlq: false, // DLQ disabled
+      method: 'POST',
+      retryDelay: 100,
+      headers: {},
+      retries: 1,
+      includeAttemptInRequests: true
+    }
+  }
+
+  const message = createMockMessage('test-topic', 'test-value')
+
+  let dlqMessageReceived = false
+  stream.on('data', () => {
+    dlqMessageReceived = true
+  })
+
+  await processMessage(logger, dlqProducer, mappings, message, metrics)
+  await sleep(1000) // Wait to ensure no DLQ message is sent
+
+  // Verify failure metrics but no DLQ metrics
+  strictEqual(metrics.messagesProcessed.getCount('test-topic', 'failed'), 1)
+  strictEqual(metrics.dlqMessages.getCount('test-topic', 'network_error'), 0)
+  strictEqual(dlqMessageReceived, false)
+
+  // Verify error was logged instead
+  const logs = logger.getLogs()
+  ok(logs.some(log => log.level === 'error' && log.obj.dlqMessage))
+})


### PR DESCRIPTION
Add a few Prometheus metrics that can be then consumed (for instance by `watt-admin`)